### PR TITLE
changed the sign in success url to imaqal page

### DIFF
--- a/public/media_engagement/auth.html
+++ b/public/media_engagement/auth.html
@@ -11,7 +11,7 @@
     <script>
         // FirebaseUI config.
         var uiConfig = {
-            signInSuccessUrl: "imaqal_sms_traffic.html",
+            signInSuccessUrl: "../coda/coding_progress.html",
             signInOptions: [
             firebase.auth.GoogleAuthProvider.PROVIDER_ID
             ],     

--- a/public/media_engagement/auth.html
+++ b/public/media_engagement/auth.html
@@ -11,7 +11,7 @@
     <script>
         // FirebaseUI config.
         var uiConfig = {
-            signInSuccessUrl: "media_engagement.html",
+            signInSuccessUrl: "imaqal_sms_traffic.html",
             signInOptions: [
             firebase.auth.GoogleAuthProvider.PROVIDER_ID
             ],     


### PR DESCRIPTION
The error when login into the dashboard after signing out from one of the sms traffic pages is encountered since the  'signInSuccessUrl' attribute was set to the earlier name of sms traffic page which was renamed for clarity, Therefore I have changed it to Imaqal page.