### PR TITLE
Fix the last updated timestamp alerts showing false positives

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -17,6 +17,7 @@ class Controller {
         let DOMstrings = UIController.getDOMstrings();
         document.querySelector(DOMstrings.codingProgressContainer).innerHTML = "";
         document.querySelector(DOMstrings.graphContainer).innerHTML = "";
+        GraphController.clearTimers();
     }
 
     static displayCodingProgress() {

--- a/public/graph.js
+++ b/public/graph.js
@@ -785,8 +785,21 @@ class GraphController {
                 difference_minutes = Math.floor(difference_ms % 60);
             if (difference_minutes > 30) {
                 d3.select("#lastUpdated").classed("text-stale-info alert alert-stale-info", true);
+            } else {
+                d3.select("#lastUpdated").classed("text-stale-info alert alert-stale-info", false);
             }
         }
-        setInterval(setLastUpdatedAlert, 1000);
+        
+        if (GraphController.lastUpdateTimer) {
+            clearInterval(GraphController.lastUpdateTimer);
+        }
+        GraphController.lastUpdateTimer = setInterval(setLastUpdatedAlert, 1000);
+    }
+    
+    static clearTimers() {
+        if (GraphController.lastUpdateTimer) {
+            clearInterval(GraphController.lastUpdateTimer);
+            GraphController.lastUpdateTimer = null;
+        }
     }
 }


### PR DESCRIPTION
I think the false positives were being displayed when there was a genuine true positive missed update (which could happen while a machine was sleeping, and cause a UI updated on wake before the new data synced) and then no clearing of the alert once the new data had synced.

To fix this I had to:
 - Update the interval to clear the alert classes once we receive new data that's < 30 minutes old.
 - Clear the previous interval timer, otherwise it would keep firing, resulting in a "fight" between timers that were trying to set the alert classes and timers that were trying to clear it.

Fixes #139 and fixes #140.