### PR TITLE
Enable Tooltips for received one day view stacked bar graphs

### DIFF
--- a/public/graph.js
+++ b/public/graph.js
@@ -467,10 +467,12 @@ class GraphController {
                         .html(d => { 
                             let receivedMessages = d.data[operatorNameWithMessageDirection],
                                 totalReceivedMessages = d.data.total_received,
-                                // Tooltip with operator name, date, no. of msg(s) & msg percentage in that day.
-                                tooltipContent = `<div>${operatorName.charAt(0).toUpperCase() + operatorName.slice(1)}</div>`;
-                            return tooltipContent += `<div>${receivedMessages} Message${receivedMessages !== 1 ? 's': ''} 
-                            (${Math.round((receivedMessages/totalReceivedMessages)*100)}%)</div>`;
+                                // Tooltip with operator name, no. of msg(s) & msg percentage in that day.
+                                tooltipContent = `<div>${receivedMessages} 
+                                (${Math.round((receivedMessages/totalReceivedMessages)*100)}%)
+                                ${operatorName.charAt(0).toUpperCase() + operatorName.slice(1)} 
+                                Message${receivedMessages !== 1 ? 's': ''} </div>`;
+                            return tooltipContent;
                     })
                     total_received_sms_graph.call(tip)
                     tip.show(d, n[i]).style("color", operatorColor)

--- a/public/graph.js
+++ b/public/graph.js
@@ -548,7 +548,8 @@ class GraphController {
                             let receivedMessages = d.data[operatorReceived],
                                 totalReceivedMessages = d.data.total_received,
                                 receivedDay = d.data.day,
-                                tooltipContent = `<div>${operatorName} ${dayDateFormatWithoutYear(new Date(receivedDay))}</div>`;
+                                tooltipContent = `<div>${operatorName.charAt(0).toUpperCase() + operatorName.slice(1)} 
+                                ${dayDateFormatWithoutYear(new Date(receivedDay))}</div>`;
                             return tooltipContent += `<div>${receivedMessages} Message${receivedMessages !== 1 ? 's': ''} 
                             (${Math.round((receivedMessages/totalReceivedMessages)*100)}%)</div>`;
                     })

--- a/public/graph.js
+++ b/public/graph.js
@@ -456,16 +456,16 @@ class GraphController {
                 .selectAll("rect")
                 .on("mouseover", (d, i, n) => {
                     // Get key of stacked data from the selection
-                    let operatorReceived = d3.select(n[i].parentNode).datum().key,
+                    let operatorNameWithMessageDirection = d3.select(n[i].parentNode).datum().key,
                         // Get operator name from the key
-                        operatorName = operatorReceived.replace('_received',''),
+                        operatorName = operatorNameWithMessageDirection.replace('_received',''),
                         // Get color of hovered rect
                         operatorColor = d3.select(n[i]).style("fill");
                     tip = d3.tip()
                         .attr("class", "tooltip")
                         .attr("id", "tooltip")
                         .html(d => { 
-                            let receivedMessages = d.data[operatorReceived],
+                            let receivedMessages = d.data[operatorNameWithMessageDirection],
                                 totalReceivedMessages = d.data.total_received,
                                 // Tooltip with operator name, date, no. of msg(s) & msg percentage in that day.
                                 tooltipContent = `<div>${operatorName.charAt(0).toUpperCase() + operatorName.slice(1)}</div>`;

--- a/public/graph.js
+++ b/public/graph.js
@@ -467,7 +467,6 @@ class GraphController {
                         .html(d => { 
                             let receivedMessages = d.data[operatorReceived],
                                 totalReceivedMessages = d.data.total_received,
-                                receivedDay = d.data.day,
                                 // Tooltip with operator name, date, no. of msg(s) & msg percentage in that day.
                                 tooltipContent = `<div>${operatorName.charAt(0).toUpperCase() + operatorName.slice(1)}</div>`;
                             return tooltipContent += `<div>${receivedMessages} Message${receivedMessages !== 1 ? 's': ''} 

--- a/public/graph.js
+++ b/public/graph.js
@@ -537,17 +537,20 @@ class GraphController {
             receivedLayer
                 .selectAll("rect")
                 .on("mouseover", (d, i, n) => {
-                    // Get color of hovered rect
+                    // Get key of stacked data from the selection
                     let operatorReceived = d3.select(n[i].parentNode).datum().key,
+                        // Get operator name from the key
                         operatorName = operatorReceived.replace('_received',''),
+                        // Get color of hovered rect
                         operatorColor = d3.select(n[i]).style("fill");
                     tip = d3.tip()
                         .attr("class", "tooltip")
                         .attr("id", "tooltip")
-                        .html(d => {
+                        .html(d => { 
                             let receivedMessages = d.data[operatorReceived],
                                 totalReceivedMessages = d.data.total_received,
                                 receivedDay = d.data.day,
+                                // Tooltip with operator name, date, no. of msg(s) & msg percentage in that day.
                                 tooltipContent = `<div>${operatorName.charAt(0).toUpperCase() + operatorName.slice(1)} 
                                 ${dayDateFormatWithoutYear(new Date(receivedDay))}</div>`;
                             return tooltipContent += `<div>${receivedMessages} Message${receivedMessages !== 1 ? 's': ''} 

--- a/public/graph.js
+++ b/public/graph.js
@@ -403,14 +403,9 @@ class GraphController {
             somtel:  "#800000",
             telegram: "#f032e6",
             telesom:  "#911eb4",
-            Other:  "#e6194b"
-        };
-
-        let operators_identity2 = {
-            NC: "#31cece",
-            telegram: "#3cb44b",
+            Other:  "#e6194b",
             "kenyan telephone": "#f58231",
-        }
+        };
 
         // Assign legend color for a given operator
         function legendColorToOperator(color) {

--- a/public/graph.js
+++ b/public/graph.js
@@ -17,6 +17,7 @@ class GraphController {
             isYLimitSentManuallySet = false,
             isYLimitFailedManuallySet = false,
             dayDateFormat = d3.timeFormat("%Y-%m-%d"),
+            dayDateFormatWithoutYear = d3.timeFormat("%a %b %d"),
             dayDateFormatWithWeekdayName = d3.timeFormat("%Y-%m-%d:%a"),
             operators = new Set();
 
@@ -537,23 +538,22 @@ class GraphController {
                 .selectAll("rect")
                 .on("mouseover", (d, i, n) => {
                     // Get color of hovered rect
-                    let rgb = d3.select(n[i]).style("fill")
-                    // Get color components from an rgb string
-                    rgb = rgb.substring(4, rgb.length-1).replace(/ /g, '').split(',');
-                    // Cast strings in array to int
-                    rgb = rgb.map((x) =>parseInt(x));
-                    let hex = rgbToHex(...rgb)
-                    let operatorOnHover = legendColorToOperator(hex)
+                    let operatorReceived = d3.select(n[i].parentNode).datum().key,
+                        operatorName = operatorReceived.replace('_received',''),
+                        operatorColor = d3.select(n[i]).style("fill");
                     tip = d3.tip()
                         .attr("class", "tooltip")
                         .attr("id", "tooltip")
                         .html(d => {
-                            let total_receved_no = d.data[`${operatorOnHover}_received`]
-                            let tooltip_content = `<div>${operatorOnHover} ${total_receved_no}</div>`  
-                            return tooltip_content;
+                            let receivedMessages = d.data[operatorReceived],
+                                totalReceivedMessages = d.data.total_received,
+                                receivedDay = d.data.day,
+                                tooltipContent = `<div>${operatorName} ${dayDateFormatWithoutYear(new Date(receivedDay))}</div>`;
+                            return tooltipContent += `<div>${receivedMessages} Message${receivedMessages !== 1 ? 's': ''} 
+                            (${Math.round((receivedMessages/totalReceivedMessages)*100)}%)</div>`;
                     })
                     total_received_sms_graph.call(tip)
-                    tip.show(d, n[i]).attr("id","here").style("color", hex)
+                    tip.show(d, n[i]).style("color", operatorColor)
                 })
                 .on("mouseout", (d, i, n) => {
                     tip.hide()

--- a/public/graph.js
+++ b/public/graph.js
@@ -383,6 +383,16 @@ class GraphController {
             drawOneDaySentGraph(yLimitSent);
         }
 
+        // Performs RGB to hex conversion and add any required zero padding
+        function componentToHex(c) {
+            var hex = c.toString(16);
+                return hex.length == 1 ? "0" + hex : hex;
+            }
+
+        function rgbToHex(r, g, b) {
+            return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
+        }
+
         let operators_identity = {
             NC: "#31cece",
             telegram: "#f032e6",

--- a/public/graph.js
+++ b/public/graph.js
@@ -533,6 +533,7 @@ class GraphController {
                 )
                 .attr("width", Width / Object.keys(dailyReceivedTotal).length);
 
+            // Add tooltip for the total received sms graph
             let tip;
             receivedLayer
                 .selectAll("rect")
@@ -563,7 +564,7 @@ class GraphController {
                     tip.hide()
                 })
 
-            //Add the X Axis for the total received sms graph
+            // "Add the X Axis for the total received sms graph
             total_received_sms_graph
                 .append("g")
                 .attr("class", "redrawElementReceived")

--- a/public/graph.js
+++ b/public/graph.js
@@ -17,7 +17,6 @@ class GraphController {
             isYLimitSentManuallySet = false,
             isYLimitFailedManuallySet = false,
             dayDateFormat = d3.timeFormat("%Y-%m-%d"),
-            dayDateFormatWithoutYear = d3.timeFormat("%a %b %d"),
             dayDateFormatWithWeekdayName = d3.timeFormat("%Y-%m-%d:%a"),
             operators = new Set();
 
@@ -470,8 +469,7 @@ class GraphController {
                                 totalReceivedMessages = d.data.total_received,
                                 receivedDay = d.data.day,
                                 // Tooltip with operator name, date, no. of msg(s) & msg percentage in that day.
-                                tooltipContent = `<div>${operatorName.charAt(0).toUpperCase() + operatorName.slice(1)} 
-                                ${dayDateFormatWithoutYear(new Date(receivedDay))}</div>`;
+                                tooltipContent = `<div>${operatorName.charAt(0).toUpperCase() + operatorName.slice(1)}</div>`;
                             return tooltipContent += `<div>${receivedMessages} Message${receivedMessages !== 1 ? 's': ''} 
                             (${Math.round((receivedMessages/totalReceivedMessages)*100)}%)</div>`;
                     })

--- a/public/graph.js
+++ b/public/graph.js
@@ -549,7 +549,7 @@ class GraphController {
                         .attr("class", "tooltip2")
                         .attr("id", "tooltip2")
                         .html(d => {
-                            let num = d.data[`${op}_received`]
+                            let total_receved_no = d.data[`${op}_received`]
                             let tooltip_content = `<div>${op} ${num}</div>`  
                             return content;
                     })

--- a/public/graph.js
+++ b/public/graph.js
@@ -527,8 +527,8 @@ class GraphController {
                 yLimitReceived = yLimitReceivedTotal;
             }
 
-            xMin = d3.min(data, d => new Date(d.day));
-            xMax = d3.max(data, d => GraphController.addOneDayToDate(d.day));
+            let xMin = d3.min(data, d => new Date(d.day)),
+                xMax = d3.max(data, d => GraphController.addOneDayToDate(d.day));
             // set scale domains
             x.domain([xMin, xMax]);
             y_total_received_sms_range.domain([0, yLimitReceived]);
@@ -701,8 +701,8 @@ class GraphController {
                 yLimitSent = yLimitSentTotal;
             }
 
-            xMin = d3.min(data, d => new Date(d.day));
-            xMax = d3.max(data, d => GraphController.addOneDayToDate(d.day));
+            let xMin = d3.min(data, d => new Date(d.day)),
+                xMax = d3.max(data, d => GraphController.addOneDayToDate(d.day));
             // set scale domains
             x.domain([xMin, xMax]);
             y_total_sent_sms.domain([0, yLimitSent]);

--- a/public/graph.js
+++ b/public/graph.js
@@ -366,37 +366,6 @@ class GraphController {
             drawOneDayFailedGraph(yLimitFailed);
         }
 
-        // Performs RGB to hex conversion and add any required zero padding
-        function componentToHex(c) {
-            var hex = c.toString(16);
-                return hex.length == 1 ? "0" + hex : hex;
-            }
-
-        function rgbToHex(r, g, b) {
-            return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
-        }
-        
-        // Assign legend color for a given operator
-        function legendColorToOperator(color) {
-            let key, received_operators = [];
-            receivedKeys.forEach(key => {
-                received_operators.push(key.split("_")[0])
-            })
-
-            const operatorsFiltered = Object.keys(MNOColors)
-                .filter(key => received_operators.includes(key))
-                .reduce((obj, key) => {
-                    return {
-                        ...obj,
-                        [key]: MNOColors[key]
-                        };
-                }, {})
-
-            key = Object.keys(operatorsFiltered).find(
-                key => operatorsFiltered[key].toLowerCase() === color.toLowerCase());
-            return key
-        }
-
         function draw10MinReceivedGraph(yLimitReceived) {
             // Set Y axis limit to max of daily values or to the value inputted by the user
             if (isYLimitReceivedManuallySet == false) {

--- a/public/graph.js
+++ b/public/graph.js
@@ -544,7 +544,6 @@ class GraphController {
                     rgb = rgb.map((x) =>parseInt(x));
                     let hex = rgbToHex(...rgb)
                     let op = legendColorToOperator(hex)
-                
                     tip = d3.tip()
                         .attr("class", "tooltip2")
                         .attr("id", "tooltip2")
@@ -554,7 +553,6 @@ class GraphController {
                             return content;
                     })
                     total_received_sms_graph.call(tip)
-    
                     tip.show(d, n[i]).attr("id","here").style("color", hex)
                 })
                 .on("mouseout", (d, i, n) => {

--- a/public/graph.js
+++ b/public/graph.js
@@ -551,7 +551,6 @@ class GraphController {
                             let content = `<div>${op} ${num}</div>` 
                             return content;
                     })
-
                     total_received_sms_graph.call(tip)
     
                     tip.show(d, n[i]).attr("id","here").style("color", hex)

--- a/public/graph.js
+++ b/public/graph.js
@@ -374,21 +374,7 @@ class GraphController {
         function rgbToHex(r, g, b) {
             return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
         }
-
-        let operators_identity = {
-            NC: "#31cece",
-            telegram: "#f032e6",
-            golis: "#f58231",
-            hormud: "#3cb44b",
-            nationlink: "#cccc00",
-            somnet: "#4363d8",
-            somtel:  "#800000",
-            telegram: "#f032e6",
-            telesom:  "#911eb4",
-            Other:  "#e6194b",
-            "kenyan telephone": "#f58231",
-        };
-
+        
         // Assign legend color for a given operator
         function legendColorToOperator(color) {
             let key, received_operators = [];
@@ -396,16 +382,17 @@ class GraphController {
                 received_operators.push(key.split("_")[0])
             })
 
-            const operatorsFiltered = Object.keys(operators_identity)
+            const operatorsFiltered = Object.keys(MNOColors)
                 .filter(key => received_operators.includes(key))
                 .reduce((obj, key) => {
                     return {
                         ...obj,
-                        [key]: operators_identity[key]
+                        [key]: MNOColors[key]
                         };
                 }, {})
 
-            key = Object.keys(operatorsFiltered).find(key => operatorsFiltered[key] === color);
+            key = Object.keys(operatorsFiltered).find(
+                key => operatorsFiltered[key].toLowerCase() === color.toLowerCase());
             return key
         }
 

--- a/public/graph.js
+++ b/public/graph.js
@@ -383,6 +383,25 @@ class GraphController {
             drawOneDaySentGraph(yLimitSent);
         }
 
+        let operators_identity = {
+            NC: "#31cece",
+            telegram: "#f032e6",
+            golis: "#f58231",
+            hormud: "#3cb44b",
+            nationlink: "#cccc00",
+            somnet: "#4363d8",
+            somtel:  "#800000",
+            telegram: "#f032e6",
+            telesom:  "#911eb4",
+            Other:  "#e6194b"
+        };
+
+        let operators_identity2 = {
+            NC: "#31cece",
+            telegram: "#3cb44b",
+            "kenyan telephone": "#f58231",
+        }
+
         function draw10MinReceivedGraph(yLimitReceived) {
             // Set Y axis limit to max of daily values or to the value inputted by the user
             if (isYLimitReceivedManuallySet == false) {

--- a/public/graph.js
+++ b/public/graph.js
@@ -561,6 +561,36 @@ class GraphController {
                 )
                 .attr("width", Width / Object.keys(dailyReceivedTotal).length);
 
+            let tip;
+            receivedLayer
+                .selectAll("rect")
+                .on("mouseover", (d, i, n) => {
+                    // Get color of hovered rect
+                    let rgb = d3.select(n[i]).style("fill")
+                    // Get color components from an rgb string
+                    rgb = rgb.substring(4, rgb.length-1).replace(/ /g, '').split(',');
+                    // Cast strings in array to int
+                    rgb = rgb.map((x) =>parseInt(x));
+                    let hex = rgbToHex(...rgb)
+                    let op = legendColorToOperator(hex)
+                
+                    tip = d3.tip()
+                        .attr("class", "tooltip2")
+                        .attr("id", "tooltip2")
+                        .html(d => {
+                            let num = d.data[`${op}_received`]
+                            let content = `<div>${op} ${num}</div>` 
+                            return content;
+                    })
+
+                    total_received_sms_graph.call(tip)
+    
+                    tip.show(d, n[i]).attr("id","here").style("color", hex)
+                })
+                .on("mouseout", (d, i, n) => {
+                    tip.hide()
+                })
+
             //Add the X Axis for the total received sms graph
             total_received_sms_graph
                 .append("g")

--- a/public/graph.js
+++ b/public/graph.js
@@ -545,8 +545,8 @@ class GraphController {
                     let hex = rgbToHex(...rgb)
                     let op = legendColorToOperator(hex)
                     tip = d3.tip()
-                        .attr("class", "tooltip2")
-                        .attr("id", "tooltip2")
+                        .attr("class", "tooltip")
+                        .attr("id", "tooltip")
                         .html(d => {
                             let total_receved_no = d.data[`${op}_received`]
                             let tooltip_content = `<div>${op} ${num}</div>`  

--- a/public/graph.js
+++ b/public/graph.js
@@ -412,6 +412,26 @@ class GraphController {
             "kenyan telephone": "#f58231",
         }
 
+        // Assign legend color for a given operator
+        function legendColorToOperator(color) {
+            let key, received_operators = [];
+            receivedKeys.forEach(key => {
+                received_operators.push(key.split("_")[0])
+            })
+
+            const operatorsFiltered = Object.keys(operators_identity)
+                .filter(key => perators.includes(key))
+                .reduce((obj, key) => {
+                    return {
+                        ...obj,
+                        [key]: operators_identity[key]
+                        };
+                }, {})
+
+            key = Object.keys(operatorsFiltered).find(key => operatorsFiltered[key] === color);
+            return key
+        }
+
         function draw10MinReceivedGraph(yLimitReceived) {
             // Set Y axis limit to max of daily values or to the value inputted by the user
             if (isYLimitReceivedManuallySet == false) {

--- a/public/graph.js
+++ b/public/graph.js
@@ -550,7 +550,7 @@ class GraphController {
                         .attr("id", "tooltip2")
                         .html(d => {
                             let num = d.data[`${op}_received`]
-                            let content = `<div>${op} ${num}</div>` 
+                            let tooltip_content = `<div>${op} ${num}</div>`  
                             return content;
                     })
                     total_received_sms_graph.call(tip)

--- a/public/graph.js
+++ b/public/graph.js
@@ -543,14 +543,14 @@ class GraphController {
                     // Cast strings in array to int
                     rgb = rgb.map((x) =>parseInt(x));
                     let hex = rgbToHex(...rgb)
-                    let op = legendColorToOperator(hex)
+                    let operatorOnHover = legendColorToOperator(hex)
                     tip = d3.tip()
                         .attr("class", "tooltip")
                         .attr("id", "tooltip")
                         .html(d => {
-                            let total_receved_no = d.data[`${op}_received`]
-                            let tooltip_content = `<div>${op} ${num}</div>`  
-                            return content;
+                            let total_receved_no = d.data[`${operatorOnHover}_received`]
+                            let tooltip_content = `<div>${operatorOnHover} ${total_receved_no}</div>`  
+                            return tooltip_content;
                     })
                     total_received_sms_graph.call(tip)
                     tip.show(d, n[i]).attr("id","here").style("color", hex)

--- a/public/graph.js
+++ b/public/graph.js
@@ -415,7 +415,7 @@ class GraphController {
             })
 
             const operatorsFiltered = Object.keys(operators_identity)
-                .filter(key => perators.includes(key))
+                .filter(key => received_operators.includes(key))
                 .reduce((obj, key) => {
                     return {
                         ...obj,

--- a/public/index.html
+++ b/public/index.html
@@ -48,6 +48,7 @@
     <section class="graph-container"></section>
     <script src="vendor/d3-5.12.0/d3.js"></script>
     <script src="vendor/d3-legend-2.25.6/d3-legend.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.9.1/d3-tip.min.js"></script>
     <script src="auth.js"></script>
     <script src="data.js"></script>
     <script src="UI.js"></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -197,7 +197,7 @@ table > tbody > tr > td {
 .alert-stale-info {
     background-color: #f08080;
 }
-.tooltip2 {	
+.tooltip{	
     position: absolute;		
     text-align: center;			
     padding: 4px;				

--- a/public/styles.css
+++ b/public/styles.css
@@ -197,3 +197,12 @@ table > tbody > tr > td {
 .alert-stale-info {
     background-color: #f08080;
 }
+.tooltip2 {	
+    position: absolute;		
+    text-align: center;			
+    padding: 4px;				
+    font: 12px sans-serif;		
+    background: whitesmoke;	
+    border-radius: 8px;			
+    pointer-events: none;			
+}


### PR DESCRIPTION
Added tooltips for the received one day stacked bar graph. Look at this before I apply the tooltips to all the stacked bar graphs
Implementation: When one hovers on a bar graph I'll get the color of the bar and I'll use a function to look up the name of the operator that matches the color as defined in the variable `operator_identity`. I'll query the data for the given operator to output the number of messages on the tooltip.
<img width="233" alt="tooltips" src="https://user-images.githubusercontent.com/39700595/78115573-aa5e7200-740b-11ea-9580-e4286e259b8c.png">
