### PR TITLE
upgrade firebase rules to version 2

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,3 +1,4 @@
+rules_version = "2";
 service cloud.firestore {
   match /databases/{database}/documents {
     match /{document=**} {


### PR DESCRIPTION
This upgrades firebase rules to version 2 to resolve the following issue. 
![image](https://user-images.githubusercontent.com/23135322/78878611-554ddc00-7a5b-11ea-9c27-b349833e5d84.png)
More info on version 2: https://firebase.google.com/docs/firestore/security/get-started
