### PR TITLE
Add Gridlines to Graphs

### DIFF
--- a/public/graph.js
+++ b/public/graph.js
@@ -526,7 +526,6 @@ class GraphController {
                 })
 
             // "Add the X Axis for the total received sms graph
-            const tickValuesForAxis = dailyReceivedTotal.map(d => new Date(d.day));
             total_received_sms_graph
                 .append("g")
                 .attr("class", "redrawElementReceived")

--- a/public/graph.js
+++ b/public/graph.js
@@ -875,6 +875,28 @@ class GraphController {
             d3.selectAll("#failedBarChart10min").remove();
             d3.selectAll(".failedGrid").remove();
 
+            // Group data filtered by week daily and generate tick values for x axis
+            let dataFilteredWeekGroupedDaily  = d3.nest().key(d => d.day).entries(dataFilteredWeek);
+            let tickValuesForXAxis = dataFilteredWeekGroupedDaily.map(d => new Date(d.key)).slice(1)
+           
+            // Add the X gridlines
+            total_failed_sms_graph.append("g")			
+                .attr("class", "failedGrid")
+                .attr("transform", "translate(0," + Height + ")")
+                .call(d3.axisBottom(x)
+                    .tickValues(tickValuesForXAxis)
+                    .tickSize(-Height)
+                    .tickFormat("")
+                )
+
+            // Add the Y gridlines
+            total_failed_sms_graph.append("g")			
+                .attr("class", "failedGrid")
+                .call(d3.axisLeft(y_total_failed_sms_range)
+                    .tickSize(-Width)
+                    .tickFormat("")
+                )
+
             // Add the Y Axis for the total failed sms graph
             total_failed_sms_graph
                 .append("g")

--- a/public/graph.js
+++ b/public/graph.js
@@ -337,8 +337,24 @@ class GraphController {
             d3.selectAll(".receivedGrid").remove();
 
             // Group data filtered by week daily and generate tick values for x axis
-            let dataFilteredWeekGroupedDaily  = d3.nest().key(d => d.day).entries(dataFilteredWeek);
-            let tickValuesForXAxis = dataFilteredWeekGroupedDaily.map(d => new Date(d.key)).slice(1)
+            let dataFilteredWeekGroupedDaily  = d3.nest().key(d => d.day)
+            .rollup(v => {
+                let firstTimestampOfDay = {}
+                firstTimestampOfDay["datetime"] = d3.min(v,d => d.datetime)
+                return firstTimestampOfDay
+            })
+            .entries(dataFilteredWeek);
+
+            // Flatten nested data
+            for (let entry in dataFilteredWeekGroupedDaily) {
+                let valueList = dataFilteredWeekGroupedDaily[entry].value;
+                for (let key in valueList) {
+                    dataFilteredWeekGroupedDaily[entry][key] = valueList[key];
+                }
+                delete dataFilteredWeekGroupedDaily[entry]["value"];
+                delete dataFilteredWeekGroupedDaily[entry]["key"];
+            }
+            const tickValuesForXAxis = dataFilteredWeekGroupedDaily.map(d => d.datetime);
            
             // Add the X gridlines
             total_received_sms_graph.append("g")			

--- a/public/graph.js
+++ b/public/graph.js
@@ -775,7 +775,6 @@ class GraphController {
                 })
 
             //Add the X Axis for the total sent sms graph
-            const tickValuesForAxis = dailySentTotal.map(d => new Date(d.day));
             total_sent_sms_graph
                 .append("g")
                 .attr("class", "redrawElementSent")

--- a/public/graph.js
+++ b/public/graph.js
@@ -443,6 +443,26 @@ class GraphController {
             d3.selectAll(".redrawElementReceived").remove();
             d3.selectAll("#receivedStack10min").remove();
             d3.selectAll("#receivedStack").remove();
+            d3.selectAll(".receivedGrid").remove();
+
+            // Add the X gridlines
+            const tickValuesForXAxis = dailyReceivedTotal.map(d => new Date(d.day));
+            total_received_sms_graph.append("g")			
+                .attr("class", "receivedGrid")
+                .attr("transform", "translate(0," + Height + ")")
+                .call(d3.axisBottom(x)
+                    .tickValues(tickValuesForXAxis)
+                    .tickSize(-Height)
+                    .tickFormat("")
+                )
+
+            // Add the Y gridlines
+            total_received_sms_graph.append("g")			
+                .attr("class", "receivedGrid")
+                .call(d3.axisLeft(y_total_received_sms_range)
+                    .tickSize(-Width)
+                    .tickFormat("")
+                )
 
             // Add the Y Axis for the total received sms graph
             total_received_sms_graph

--- a/public/graph.js
+++ b/public/graph.js
@@ -899,7 +899,6 @@ class GraphController {
                 })
 
             // Add the X Axis for the total failed sms graph
-            const tickValuesForAxis = dailyFailedTotal.map(d => new Date(d.day));
             total_failed_sms_graph
                 .append("g")
                 .attr("class", "redrawElementFailed")

--- a/public/graph.js
+++ b/public/graph.js
@@ -694,6 +694,7 @@ class GraphController {
             d3.selectAll(".redrawElementSent").remove();
             d3.selectAll("#sentStack10min").remove();
             d3.selectAll("#sentStack1day").remove();
+            d3.selectAll(".sentGrid").remove();
 
             // Add the Y Axis for the total sent sms graph
             total_sent_sms_graph

--- a/public/graph.js
+++ b/public/graph.js
@@ -624,7 +624,7 @@ class GraphController {
                 .call(
                     d3
                         .axisBottom(x)
-                        .ticks(d3.timeDay.every(1))
+                        .tickValues(tickValuesForXAxis)
                         .tickFormat(timeFormat)
                 )
                 // Rotate axis labels

--- a/public/graph.js
+++ b/public/graph.js
@@ -906,7 +906,7 @@ class GraphController {
                 .call(
                     d3
                         .axisBottom(failed_messages_x_axis_range)
-                        .tickValues(tickValuesForAxis)
+                        .tickValues(tickValuesForXAxis)
                         .tickFormat(d => dayDateFormatWithWeekdayName(d))
                 )
                 // Rotate axis labels

--- a/public/graph.js
+++ b/public/graph.js
@@ -925,7 +925,7 @@ class GraphController {
                 .call(
                     d3
                         .axisBottom(x)
-                        .ticks(d3.timeDay.every(1))
+                        .tickValues(tickValuesForXAxis)
                         .tickFormat(timeFormat)
                 )
                 // Rotate axis labels

--- a/public/graph.js
+++ b/public/graph.js
@@ -696,6 +696,25 @@ class GraphController {
             d3.selectAll("#sentStack1day").remove();
             d3.selectAll(".sentGrid").remove();
 
+            // Add the X gridlines
+            const tickValuesForXAxis = dailySentTotal.map(d => new Date(d.day));
+            total_sent_sms_graph.append("g")			
+                .attr("class", "sentGrid")
+                .attr("transform", "translate(0," + Height + ")")
+                .call(d3.axisBottom(x)
+                    .tickValues(tickValuesForXAxis)
+                    .tickSize(-Height)
+                    .tickFormat("")
+                )
+
+            // Add the Y gridlines
+            total_sent_sms_graph.append("g")			
+                .attr("class", "sentGrid")
+                .call(d3.axisLeft(y_total_sent_sms_range)
+                    .tickSize(-Width)
+                    .tickFormat("")
+                )
+
             // Add the Y Axis for the total sent sms graph
             total_sent_sms_graph
                 .append("g")

--- a/public/graph.js
+++ b/public/graph.js
@@ -833,6 +833,26 @@ class GraphController {
             d3.selectAll(".redrawElementFailed").remove();
             d3.selectAll("#failedBarChart").remove();
             d3.selectAll("#failedBarChart10min").remove();
+            d3.selectAll(".failedGrid").remove();
+
+            // Add the X gridlines
+            const tickValuesForXAxis = dailyFailedTotal.map(d => new Date(d.day));
+            total_failed_sms_graph.append("g")			
+                .attr("class", "failedGrid")
+                .attr("transform", "translate(0," + Height + ")")
+                .call(d3.axisBottom(x)
+                    .tickValues(tickValuesForXAxis)
+                    .tickSize(-Height)
+                    .tickFormat("")
+                )
+
+            // Add the Y gridlines
+            total_failed_sms_graph.append("g")			
+                .attr("class", "failedGrid")
+                .call(d3.axisLeft(y_total_failed_sms_range)
+                    .tickSize(-Width)
+                    .tickFormat("")
+                )
 
             // Add the Y Axis for the total failed sms graph
             total_failed_sms_graph

--- a/public/graph.js
+++ b/public/graph.js
@@ -614,9 +614,26 @@ class GraphController {
             d3.selectAll(".sentGrid").remove();
 
             // Group data filtered by week daily and generate tick values for x axis
-            let dataFilteredWeekGroupedDaily  = d3.nest().key(d => d.day).entries(dataFilteredWeek);
-            let tickValuesForXAxis = dataFilteredWeekGroupedDaily.map(d => new Date(d.key)).slice(1)
-           
+            let dataFilteredWeekGroupedDaily  = d3.nest().key(d => d.day)
+            .rollup(v => {
+                let firstTimestampOfDay = {}
+                firstTimestampOfDay["datetime"] = d3.min(v,d => d.datetime)
+                return firstTimestampOfDay
+            })
+            .entries(dataFilteredWeek);
+
+            // Flatten nested data
+            for (let entry in dataFilteredWeekGroupedDaily) {
+                let valueList = dataFilteredWeekGroupedDaily[entry].value;
+                for (let key in valueList) {
+                    dataFilteredWeekGroupedDaily[entry][key] = valueList[key];
+                }
+                delete dataFilteredWeekGroupedDaily[entry]["value"];
+                delete dataFilteredWeekGroupedDaily[entry]["key"];
+            }
+            const tickValuesForXAxis = dataFilteredWeekGroupedDaily.map(d => d.datetime);
+
+
             // Add the X gridlines
             total_sent_sms_graph.append("g")			
                 .attr("class", "sentGrid")
@@ -993,8 +1010,24 @@ class GraphController {
             d3.selectAll(".failedGrid").remove();
 
             // Group data filtered by week daily and generate tick values for x axis
-            let dataFilteredWeekGroupedDaily  = d3.nest().key(d => d.day).entries(dataFilteredWeek);
-            let tickValuesForXAxis = dataFilteredWeekGroupedDaily.map(d => new Date(d.key)).slice(1)
+            let dataFilteredWeekGroupedDaily  = d3.nest().key(d => d.day)
+            .rollup(v => {
+                let firstTimestampOfDay = {}
+                firstTimestampOfDay["datetime"] = d3.min(v,d => d.datetime)
+                return firstTimestampOfDay
+            })
+            .entries(dataFilteredWeek);
+
+            // Flatten nested data
+            for (let entry in dataFilteredWeekGroupedDaily) {
+                let valueList = dataFilteredWeekGroupedDaily[entry].value;
+                for (let key in valueList) {
+                    dataFilteredWeekGroupedDaily[entry][key] = valueList[key];
+                }
+                delete dataFilteredWeekGroupedDaily[entry]["value"];
+                delete dataFilteredWeekGroupedDaily[entry]["key"];
+            }
+            const tickValuesForXAxis = dataFilteredWeekGroupedDaily.map(d => d.datetime);
            
             // Add the X gridlines
             total_failed_sms_graph.append("g")			

--- a/public/graph.js
+++ b/public/graph.js
@@ -533,7 +533,7 @@ class GraphController {
                 .call(
                     d3
                         .axisBottom(x)
-                        .tickValues(tickValuesForAxis)
+                        .tickValues(tickValuesForXAxis)
                         .tickFormat(d => dayDateFormatWithWeekdayName(d))
                 )
                 // Rotate axis labels

--- a/public/graph.js
+++ b/public/graph.js
@@ -331,6 +331,7 @@ class GraphController {
             d3.selectAll(".redrawElementReceived").remove();
             d3.selectAll("#receivedStack").remove();
             d3.selectAll("#receivedStack10min").remove();
+            d3.selectAll(".receivedGrid").remove();
 
             // Add the Y Axis for the total received sms graph
             total_received_sms_graph

--- a/public/graph.js
+++ b/public/graph.js
@@ -782,7 +782,7 @@ class GraphController {
                 .call(
                     d3
                         .axisBottom(x)
-                        .tickValues(tickValuesForAxis)
+                        .tickValues(tickValuesForXAxis)
                         .tickFormat(d => dayDateFormatWithWeekdayName(d))
                 )
                 // Rotate axis labels

--- a/public/graph.js
+++ b/public/graph.js
@@ -333,6 +333,28 @@ class GraphController {
             d3.selectAll("#receivedStack10min").remove();
             d3.selectAll(".receivedGrid").remove();
 
+            // Group data filtered by week daily and generate tick values for x axis
+            let dataFilteredWeekGroupedDaily  = d3.nest().key(d => d.day).entries(dataFilteredWeek);
+            let tickValuesForXAxis = dataFilteredWeekGroupedDaily.map(d => new Date(d.key)).slice(1)
+           
+            // Add the X gridlines
+            total_received_sms_graph.append("g")			
+                .attr("class", "receivedGrid")
+                .attr("transform", "translate(0," + Height + ")")
+                .call(d3.axisBottom(x)
+                    .tickValues(tickValuesForXAxis)
+                    .tickSize(-Height)
+                    .tickFormat("")
+                )
+
+            // Add the Y gridlines
+            total_received_sms_graph.append("g")			
+                .attr("class", "receivedGrid")
+                .call(d3.axisLeft(y_total_received_sms_range)
+                    .tickSize(-Width)
+                    .tickFormat("")
+                )
+
             // Add the Y Axis for the total received sms graph
             total_received_sms_graph
                 .append("g")

--- a/public/graph.js
+++ b/public/graph.js
@@ -873,6 +873,7 @@ class GraphController {
             d3.selectAll(".redrawElementFailed").remove();
             d3.selectAll("#failedBarChart").remove();
             d3.selectAll("#failedBarChart10min").remove();
+            d3.selectAll(".failedGrid").remove();
 
             // Add the Y Axis for the total failed sms graph
             total_failed_sms_graph

--- a/public/graph.js
+++ b/public/graph.js
@@ -565,6 +565,7 @@ class GraphController {
             d3.selectAll(".redrawElementSent").remove();
             d3.selectAll("#sentStack1day").remove();
             d3.selectAll("#sentStack10min").remove();
+            d3.selectAll(".sentGrid").remove();
 
             // Add the Y Axis for the total sent sms graph
             total_sent_sms_graph

--- a/public/graph.js
+++ b/public/graph.js
@@ -392,7 +392,7 @@ class GraphController {
                 .call(
                     d3
                         .axisBottom(x)
-                        .ticks(d3.timeDay.every(1))
+                        .tickValues(tickValuesForXAxis)
                         .tickFormat(timeFormat)
                 )
                 // Rotate axis labels

--- a/public/graph.js
+++ b/public/graph.js
@@ -567,6 +567,28 @@ class GraphController {
             d3.selectAll("#sentStack10min").remove();
             d3.selectAll(".sentGrid").remove();
 
+            // Group data filtered by week daily and generate tick values for x axis
+            let dataFilteredWeekGroupedDaily  = d3.nest().key(d => d.day).entries(dataFilteredWeek);
+            let tickValuesForXAxis = dataFilteredWeekGroupedDaily.map(d => new Date(d.key)).slice(1)
+           
+            // Add the X gridlines
+            total_sent_sms_graph.append("g")			
+                .attr("class", "sentGrid")
+                .attr("transform", "translate(0," + Height + ")")
+                .call(d3.axisBottom(x)
+                    .tickValues(tickValuesForXAxis)
+                    .tickSize(-Height)
+                    .tickFormat("")
+                )
+
+            // Add the Y gridlines
+            total_sent_sms_graph.append("g")			
+                .attr("class", "sentGrid")
+                .call(d3.axisLeft(y_total_sent_sms_range)
+                    .tickSize(-Width)
+                    .tickFormat("")
+                )
+
             // Add the Y Axis for the total sent sms graph
             total_sent_sms_graph
                 .append("g")

--- a/public/styles.css
+++ b/public/styles.css
@@ -206,3 +206,22 @@ table > tbody > tr > td {
     border-radius: 8px;			
     pointer-events: none;			
 }
+.line {
+    fill: none;
+    stroke: steelblue;
+    stroke-width: 2px;
+}
+.receivedGrid line,
+.sentGrid line,
+.failedGrid line {
+    stroke: lightgrey;
+    stroke-opacity: 0.7;
+    shape-rendering: crispEdges;
+}
+.receivedGrid path,
+.sentGrid path,
+.failedGrid path {
+    stroke: lightgrey;
+    stroke-opacity: 0.7;
+    shape-rendering: crispEdges;
+}


### PR DESCRIPTION
Added grid lines to graphs as a visual aid & Changed how x-axis ticks are being generated from `.ticks(d3.timeDay.every(1)) ` to using date values from data used to plot a given graph. This avoids the error of x ticks from getting out of the graph width sometimes around midnight
<img width="216" alt="x-axis-err" src="https://user-images.githubusercontent.com/39700595/80388908-1faa4f00-88b3-11ea-9107-87e1ad5f8530.png">
