### PR TITLE
Tooltips for 10min view

### DIFF
--- a/public/graph.js
+++ b/public/graph.js
@@ -374,16 +374,16 @@ class GraphController {
                 .selectAll("rect")
                 .on("mouseover", (d, i, n) => {
                     // Get key of stacked data from the selection
-                    let operatorReceived = d3.select(n[i].parentNode).datum().key,
+                    let operatorNameWithMessageDirection = d3.select(n[i].parentNode).datum().key,
                         // Get operator name from the key
-                        operatorName = operatorReceived.replace('_received',''),
+                        operatorName = operatorNameWithMessageDirection.replace('_received',''),
                         // Get color of hovered rect
                         operatorColor = d3.select(n[i]).style("fill");
                     tip = d3.tip()
                         .attr("class", "tooltip")
                         .attr("id", "tooltip")
                         .html(d => { 
-                            let receivedMessages = d.data[operatorReceived],
+                            let receivedMessages = d.data[operatorNameWithMessageDirection],
                                 totalReceivedMessages = d.data.total_received,
                                 receivedDay = d.data.datetime,
                                 // Tooltip with operator name, date, no. of msg(s) & msg percentage in that day.
@@ -619,16 +619,16 @@ class GraphController {
                 .selectAll("rect")
                 .on("mouseover", (d, i, n) => {
                     // Get key of stacked data from the selection
-                    let operatorSent = d3.select(n[i].parentNode).datum().key,
+                    let operatorNameWithMessageDirection = d3.select(n[i].parentNode).datum().key,
                         // Get operator name from the key
-                        operatorName = operatorSent.replace('_sent',''),
+                        operatorName = operatorNameWithMessageDirection.replace('_sent',''),
                         // Get color of hovered rect
                         operatorColor = d3.select(n[i]).style("fill");
                     tip = d3.tip()
                         .attr("class", "tooltip")
                         .attr("id", "tooltip")
                         .html(d => { 
-                            let sentMessages = d.data[operatorSent],
+                            let sentMessages = d.data[operatorNameWithMessageDirection],
                                 totalSentMessages = d.data.total_sent,
                                 sentDay = d.data.datetime,
                                 // Tooltip with operator name, date, no. of msg(s) & msg percentage in that day.

--- a/public/graph.js
+++ b/public/graph.js
@@ -581,6 +581,37 @@ class GraphController {
                 .attr("height", d => y_total_sent_sms_range(d[0]) - y_total_sent_sms_range(d[1]))
                 .attr("width", Width / Object.keys(dataFilteredWeek).length);
 
+            // Add tooltip for the total received sms graph
+            let tip;
+            sentLayer10min
+                .selectAll("rect")
+                .on("mouseover", (d, i, n) => {
+                    // Get key of stacked data from the selection
+                    let operatorSent = d3.select(n[i].parentNode).datum().key,
+                        // Get operator name from the key
+                        operatorName = operatorSent.replace('_sent',''),
+                        // Get color of hovered rect
+                        operatorColor = d3.select(n[i]).style("fill");
+                    tip = d3.tip()
+                        .attr("class", "tooltip")
+                        .attr("id", "tooltip")
+                        .html(d => { 
+                            let sentMessages = d.data[operatorSent],
+                                totalSentMessages = d.data.total_sent,
+                                sentDay = d.data.datetime,
+                                // Tooltip with operator name, date, no. of msg(s) & msg percentage in that day.
+                                tooltipContent = `<div>${operatorName.charAt(0).toUpperCase() + operatorName.slice(1)}</div>`;
+                            return tooltipContent += `<div>${sentMessages} 
+                                (${Math.round((sentMessages/totalSentMessages)*100)}%)
+                                Message${sentMessages !== 1 ? 's': ''} at ${dayDateFormatWithoutYear(new Date(sentDay))}</div>`;
+                    })
+                    total_sent_sms_graph.call(tip)
+                    tip.show(d, n[i]).style("color", operatorColor)
+                })
+                .on("mouseout", (d, i, n) => {
+                    tip.hide()
+                })
+
             //Add the X Axis for the total sent sms graph
             total_sent_sms_graph
                 .append("g")

--- a/public/graph.js
+++ b/public/graph.js
@@ -891,6 +891,31 @@ class GraphController {
                 .attr("height", d => Height - y_total_failed_sms_range(d.total_errored))
                 .attr("fill", "#ff0000")
                 .attr("width", Width / Object.keys(dataFilteredWeek).length)
+            
+            // Add tooltip for the total failed sms graph
+            let tip;
+            total_failed_sms_graph
+                .selectAll("rect")
+                .on("mouseover", (d, i, n) => {
+                    let barColor = d3.select(n[i]).style("fill");
+                    tip = d3.tip()
+                        .attr("class", "tooltip")
+                        .attr("id", "tooltip")
+                        .html(d => {
+                            let totalFailedMessages = d.total_errored,
+                                failedDay = d.datetime,
+                                // Tooltip with operator name, no. of msg(s) & msg percentage in that day.
+                                tooltipContent = `<div>${totalFailedMessages} Failed
+                                Message${totalFailedMessages !== 1 ? 's': ''} at 
+                                ${dayDateFormatWithoutYear(new Date(failedDay))}</div>`;
+                            return tooltipContent;
+                        })
+                    total_failed_sms_graph.call(tip)
+                    tip.show(d, n[i]).style("color", barColor)
+                })
+                .on("mouseout", (d, i, n) => {
+                    tip.hide()
+                })
 
             // Add the X Axis for the total failed sms graph
             total_failed_sms_graph

--- a/public/graph.js
+++ b/public/graph.js
@@ -367,6 +367,37 @@ class GraphController {
                 )
                 .attr("width", Width / Object.keys(dataFilteredWeek).length);
 
+            // Add tooltip for the total received sms graph
+            let tip;
+            receivedLayer10min
+                .selectAll("rect")
+                .on("mouseover", (d, i, n) => {
+                    // Get key of stacked data from the selection
+                    let operatorReceived = d3.select(n[i].parentNode).datum().key,
+                        // Get operator name from the key
+                        operatorName = operatorReceived.replace('_received',''),
+                        // Get color of hovered rect
+                        operatorColor = d3.select(n[i]).style("fill");
+                    tip = d3.tip()
+                        .attr("class", "tooltip")
+                        .attr("id", "tooltip")
+                        .html(d => { 
+                            let receivedMessages = d.data[operatorReceived],
+                                totalReceivedMessages = d.data.total_received,
+                                receivedDay = d.data.datetime,
+                                // Tooltip with operator name, date, no. of msg(s) & msg percentage in that day.
+                                tooltipContent = `<div>${operatorName.charAt(0).toUpperCase() + operatorName.slice(1)}</div>`;
+                            return tooltipContent += `<div>${receivedMessages} 
+                                (${Math.round((receivedMessages/totalReceivedMessages)*100)}%)
+                                Message${receivedMessages !== 1 ? 's': ''} at ${dayDateFormatWithoutYear(new Date(receivedDay))}</div>`;
+                    })
+                    total_received_sms_graph.call(tip)
+                    tip.show(d, n[i]).style("color", operatorColor)
+                })
+                .on("mouseout", (d, i, n) => {
+                    tip.hide()
+                })
+
             //Add the X Axis for the total received sms graph
             total_received_sms_graph
                 .append("g")

--- a/public/graph.js
+++ b/public/graph.js
@@ -17,6 +17,7 @@ class GraphController {
             isYLimitSentManuallySet = false,
             isYLimitFailedManuallySet = false,
             dayDateFormat = d3.timeFormat("%Y-%m-%d"),
+            dayDateFormatWithoutYear = d3.timeFormat("%H:%M %p"),
             dayDateFormatWithWeekdayName = d3.timeFormat("%Y-%m-%d:%a"),
             operators = new Set();
 

--- a/public/graph.js
+++ b/public/graph.js
@@ -17,7 +17,7 @@ class GraphController {
             isYLimitSentManuallySet = false,
             isYLimitFailedManuallySet = false,
             dayDateFormat = d3.timeFormat("%Y-%m-%d"),
-            dayDateFormatWithoutYear = d3.timeFormat("%H:%M %p"),
+            dayTimeFormat = d3.timeFormat("%H:%M %p"),
             dayDateFormatWithWeekdayName = d3.timeFormat("%Y-%m-%d:%a"),
             operators = new Set();
 
@@ -390,7 +390,7 @@ class GraphController {
                                 tooltipContent = `<div>${operatorName.charAt(0).toUpperCase() + operatorName.slice(1)}</div>`;
                             return tooltipContent += `<div>${receivedMessages} 
                                 (${Math.round((receivedMessages/totalReceivedMessages)*100)}%)
-                                Message${receivedMessages !== 1 ? 's': ''} at ${dayDateFormatWithoutYear(new Date(receivedDay))}</div>`;
+                                Message${receivedMessages !== 1 ? 's': ''} at ${dayTimeFormat(new Date(receivedDay))}</div>`;
                     })
                     total_received_sms_graph.call(tip)
                     tip.show(d, n[i]).style("color", operatorColor)
@@ -635,7 +635,7 @@ class GraphController {
                                 tooltipContent = `<div>${operatorName.charAt(0).toUpperCase() + operatorName.slice(1)}</div>`;
                             return tooltipContent += `<div>${sentMessages} 
                                 (${Math.round((sentMessages/totalSentMessages)*100)}%)
-                                Message${sentMessages !== 1 ? 's': ''} at ${dayDateFormatWithoutYear(new Date(sentDay))}</div>`;
+                                Message${sentMessages !== 1 ? 's': ''} at ${dayTimeFormat(new Date(sentDay))}</div>`;
                     })
                     total_sent_sms_graph.call(tip)
                     tip.show(d, n[i]).style("color", operatorColor)
@@ -970,7 +970,7 @@ class GraphController {
                                 // Tooltip with operator name, no. of msg(s) & msg percentage in that day.
                                 tooltipContent = `<div>${totalFailedMessages} Failed
                                 Message${totalFailedMessages !== 1 ? 's': ''} at 
-                                ${dayDateFormatWithoutYear(new Date(failedDay))}</div>`;
+                                ${dayTimeFormat(new Date(failedDay))}</div>`;
                             return tooltipContent;
                         })
                     total_failed_sms_graph.call(tip)


### PR DESCRIPTION
Closes: #208
Copied code from stacked bar graphs' tooltip implementation and added time of the day to the tooltips in 10 min view as suggested in issue above. 