### PR TITLE
RESOLVE: Tooltip doesn't disappear on mouseout after taking long

### DIFF
--- a/public/graph.js
+++ b/public/graph.js
@@ -490,7 +490,7 @@ class GraphController {
                     tip.show(d, n[i]).style("color", operatorColor)
                 })
                 .on("mouseout", (d, i, n) => {
-                    tip.hide()
+                    tip.hide(d, n[i])
                 })
 
             // "Add the X Axis for the total received sms graph
@@ -702,7 +702,7 @@ class GraphController {
                     tip.show(d, n[i]).style("color", operatorColor)
                 })
                 .on("mouseout", (d, i, n) => {
-                    tip.hide()
+                    tip.hide(d, n[i])
                 })
 
             //Add the X Axis for the total sent sms graph
@@ -812,7 +812,7 @@ class GraphController {
                     tip.show(d, n[i]).style("color", barColor)
                 })
                 .on("mouseout", (d, i, n) => {
-                    tip.hide()
+                    tip.hide(d, n[i])
                 })
 
             // Add the X Axis for the total failed sms graph


### PR DESCRIPTION
On mouse out the tooltip doesn't disappear after browser taking long open. Noted this doesn't appear on safari. Resolved this on other browsers by passing node hovered and its bound data to tip.hide function on mouse out to hide the tooltip on mouse out.


Closes: #205