### PR TITLE
Compute x axis tick values for Received 10 min view graph

### DIFF
--- a/public/graph.js
+++ b/public/graph.js
@@ -339,6 +339,26 @@ class GraphController {
             d3.selectAll("#receivedStack").remove();
             d3.selectAll("#receivedStack10min").remove();
 
+            // Group data filtered by week daily and generate tick values for x axis
+            let dataFilteredWeekGroupedDaily  = d3.nest().key(d => d.day)
+                .rollup(v => {
+                    let firstTimestampOfDay = {}
+                    firstTimestampOfDay["datetime"] = d3.min(v,d => d.datetime)
+                    return firstTimestampOfDay
+                })
+                .entries(dataFilteredWeek);
+
+            // Flatten nested data
+            for (let entry in dataFilteredWeekGroupedDaily) {
+                let valueList = dataFilteredWeekGroupedDaily[entry].value;
+                for (let key in valueList) {
+                    dataFilteredWeekGroupedDaily[entry][key] = valueList[key];
+                }
+                delete dataFilteredWeekGroupedDaily[entry]["value"];
+                delete dataFilteredWeekGroupedDaily[entry]["key"];
+            }
+            const tickValuesForXAxis = dataFilteredWeekGroupedDaily.map(d => d.datetime);
+
             // Add the Y Axis for the total received sms graph
             total_received_sms_graph
                 .append("g")

--- a/public/graph.js
+++ b/public/graph.js
@@ -427,7 +427,7 @@ class GraphController {
                 .call(
                     d3
                         .axisBottom(x)
-                        .ticks(d3.timeDay.every(1))
+                        .tickValues(tickValuesForXAxis)
                         .tickFormat(timeFormat)
                 )
                 // Rotate axis labels


### PR DESCRIPTION
Changed how x-axis ticks are being generated from .ticks(d3.timeDay.every(1)) to using date values from data used to plot a given graph. This avoids the error of x ticks from getting out of the graph width sometimes around midnight
<img width="216" alt="x-axis-err" src="https://user-images.githubusercontent.com/39700595/80388908-1faa4f00-88b3-11ea-9107-87e1ad5f8530.png">