### PR TITLE
Correct Coding Progress table head structure

### DIFF
--- a/public/coding_progress.js
+++ b/public/coding_progress.js
@@ -27,6 +27,7 @@ class CodingProgressTableController {
             CodingProgressTableController.column = sortInfo.column;
 
             d3.select("tbody").selectAll("tr").remove();
+            d3.select("thead").selectAll('tr').remove();
 
             // Table Header
             d3.select("thead").selectAll("th")

--- a/public/coding_progress.js
+++ b/public/coding_progress.js
@@ -30,11 +30,12 @@ class CodingProgressTableController {
             d3.select("thead").selectAll('tr').remove();
 
             // Table Header
-            d3.select("thead").selectAll("th")
-                .data(CodingProgressTableController.jsonToArray(data[0]))
-                .enter().append("th")
+            d3.select("thead").append('tr')
                 .attr("class", "table-heading")
-                .on("click", (d) => transform(d[0]))
+                .selectAll('th')
+                .data(CodingProgressTableController.jsonToArray(data[0])).enter() 
+                .append('th')
+                .on("click", (d, i, n) => transform(d[0]))
                 .text(d => d[0])
 
             // Table Rows

--- a/public/styles.css
+++ b/public/styles.css
@@ -64,7 +64,7 @@ a {
     height: 30px;
     color: #ffff;
 }
-.table > thead > th {
+.table thead > tr > th {
     vertical-align: bottom;
     border-bottom: 2px solid #8e3436;
 }


### PR DESCRIPTION
Updated table header structure:
<img width="299" alt="Screenshot 2020-05-13 at 12 30 57" src="https://user-images.githubusercontent.com/39700595/81797283-3d182380-9517-11ea-9634-b9f89acfd248.png">

Current table header structure:
<img width="427" alt="Screenshot 2020-05-13 at 12 31 32" src="https://user-images.githubusercontent.com/39700595/81797301-41dcd780-9517-11ea-9a3b-ac3038b4405e.png">
