### PR TITLE
Update Insertion and removal method of DOM elements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -42,10 +42,7 @@
             </div>
         </div>
     </nav> 
-     <!-- Display Coding Progress Table Here -->
-    <section class="coding_progress coding-progress-container"></section>
-    <!-- Display Graphs Here -->
-    <section class="graph-container"></section>
+    <main class="main-container"></main>
     <script src="vendor/d3-5.12.0/d3.js"></script>
     <script src="vendor/d3-legend-2.25.6/d3-legend.min.js"></script>
     <script src="vendor/d3-tip-0.9.1/d3-tip.min.js"></script>

--- a/public/js/controllers/app_controller.js
+++ b/public/js/controllers/app_controller.js
@@ -84,7 +84,9 @@ class Controller {
 
     static navigateToSelectedProject(e) {
         if (e.target && e.target.nodeName == "A") {
-            Controller.resetUI();
+            import("./traffic_graphs_controller.js").then(module => {
+                module.TrafficGraphsController.clearTimers();
+            });
             DataController.detachSnapshotListener();
             console.log(e.target.innerText);
             let project = e.target.innerText;
@@ -95,7 +97,9 @@ class Controller {
 
     static navigateToSystems(e) {
         if (e.target && e.target.nodeName == "A") {
-            Controller.resetUI();
+            import("./systems_graphs_controller.js").then(module => {
+                module.SystemsGraphsController.clearTimers();
+            });
             DataController.detachSnapshotListener();
             window.location.hash = "systems";
             Controller.displaySystems();

--- a/public/js/controllers/app_controller.js
+++ b/public/js/controllers/app_controller.js
@@ -20,17 +20,6 @@ class Controller {
             .addEventListener("click", Controller.navigateToSystems);
     }
 
-    static resetUI() {
-        document.querySelector(Controller.DOMstrings.codingProgressContainer).innerHTML = "";
-        document.querySelector(Controller.DOMstrings.graphContainer).innerHTML = "";
-        import("./traffic_graphs_controller.js").then(module => {
-            module.TrafficGraphsController.clearTimers();
-        });
-        import("./systems_graphs_controller.js").then(module => {
-            module.SystemsGraphsController.clearTimers();
-        });
-    }
-
     static resetActiveLink() {
         let elements = document.querySelectorAll(Controller.DOMstrings.activeLinks);
         elements.forEach(element => {

--- a/public/js/controllers/app_controller.js
+++ b/public/js/controllers/app_controller.js
@@ -87,7 +87,6 @@ class Controller {
 
     static navigateToCodingProgress(e) {
         if (e.target && e.target.nodeName == "A") {
-            Controller.resetUI();
             DataController.detachSnapshotListener();
             window.location.hash = "coding_progress";
             Controller.displayCodingProgress();

--- a/public/js/controllers/ui_controller.js
+++ b/public/js/controllers/ui_controller.js
@@ -4,14 +4,12 @@ export class UIController {
         return {
             projectMenu: ".project-menu",
             codingProgressLinkSelector: ".coding-progress-link",
-            codingProgressContainer: ".coding-progress-container",
             trafficsLinkSelector: ".traffics-link",
-            graphContainer: ".graph-container",
+            systemsLinkSelector: ".systems-link",
             logoutBtn: ".logout-btn",
-            dropdownItem: ".dropdown-item",
             activeLinkClassName: "active-link",
             activeLinks: "a.active-link",
-            systemsLinkSelector: ".systems-link"
+            mainContainer: ".main-container"
         };
     }
 

--- a/public/js/controllers/ui_controller.js
+++ b/public/js/controllers/ui_controller.js
@@ -137,21 +137,21 @@ export class UIController {
             <section>
                 <div class="d-md-flex justify-content-start my-2">
                     <span class="font-weight-bold" type="text">Set the maximum number of incoming messages you want to see</span> 
-                    <div class="col-md-2"><input class="form-control form-control-sm" type="number" id="buttonYLimitReceived" step="100" min="10"></div>
+                    <div class="col-md-2"><input class="form-control form-control-sm shadow-none" type="number" id="buttonYLimitReceived" step="100" min="10"></div>
                 </div>
                 <div class="card shadow total_received_sms_graph"></div>
             </section> 
             <section>
                 <div class="d-md-flex justify-content-start mt-4 mb-3">
                     <span class="font-weight-bold" type="text">Set the maximum number of outgoing messages you want to see</span> 
-                    <div class="col-md-2"><input class="form-control form-control-sm" type="number" id="buttonYLimitSent" step="500" min="10"></div>
+                    <div class="col-md-2"><input class="form-control form-control-sm shadow-none" type="number" id="buttonYLimitSent" step="500" min="10"></div>
                 </div>
                 <div class="card shadow total_sent_sms_graph"></div>
             </section> 
             <section>
                 <div class="d-md-flex justify-content-start mt-4 mb-3">
                     <span class="font-weight-bold" type="text">Set the maximum number of failed messages you want to see</span> 
-                    <div class="col-md-2"><input class="form-control form-control-sm" type="number" id="buttonYLimitFailed" step="50" min="10"></div>
+                    <div class="col-md-2"><input class="form-control form-control-sm shadow-none" type="number" id="buttonYLimitFailed" step="50" min="10"></div>
                 </div>
                 <div class="card shadow total_failed_sms_graph my-4"></div> 
             </section>

--- a/public/js/controllers/ui_controller.js
+++ b/public/js/controllers/ui_controller.js
@@ -120,7 +120,7 @@ export class UIController {
         let html = `<div class="container"> 
             <div class="d-md-flex justify-content-between p-1">
                 <div>
-                    <span class="txt-brown my-auto title"><b>%collection%</b></span>
+                    <span class="txt-brown my-auto title"><b>${title}</b></span>
                 </div>
                 <div class="d-md-flex">
                     <span class="align-content-end font-weight-bold mr-1 p-1">Timescale</span>

--- a/public/js/controllers/ui_controller.js
+++ b/public/js/controllers/ui_controller.js
@@ -38,7 +38,7 @@ export class UIController {
     }
 
     static getScrollJsScript() {
-        let script = document.createElement('script');
+        let ScrollScript = document.createElement('script');
         script.setAttribute('src', 'js/libs/scroll.js');
         return script;
     }

--- a/public/js/controllers/ui_controller.js
+++ b/public/js/controllers/ui_controller.js
@@ -111,9 +111,7 @@ export class UIController {
             </div>
         </div> `;
         // Insert the HTML into the DOM
-        document
-            .querySelector(DOMstrings.codingProgressContainer)
-            .insertAdjacentHTML("beforeend", html);
+        UIController.statusBody.insertAdjacentHTML("beforeend", html);
     }
 
     static addGraphs(title) {
@@ -192,12 +190,9 @@ export class UIController {
                     </div>
                 </div>
             </div>
-        </div> `,
-            // Insert the HTML into the DOM
-            newHtml = html.replace("%collection%", title);
-        document
-            .querySelector(DOMstrings.codingProgressContainer)
-            .insertAdjacentHTML("beforeend", newHtml);
+        </div> `;
+        // Insert the HTML into the DOM
+        UIController.statusBody.insertAdjacentHTML("beforeend", html);
     }
 
     static addSystemsGraphs() {
@@ -217,8 +212,6 @@ export class UIController {
                 <div class="card shadow cpu-utilization-chart my-1"></div>
             </section> 
         </div> `;
-        document
-            .querySelector(DOMstrings.codingProgressContainer)
-            .insertAdjacentHTML("beforeend", html);
+        UIController.statusBody.insertAdjacentHTML("beforeend", html);
     }
 }

--- a/public/js/controllers/ui_controller.js
+++ b/public/js/controllers/ui_controller.js
@@ -38,9 +38,9 @@ export class UIController {
     }
 
     static getScrollJsScript() {
-        let ScrollScript = document.createElement('script');
-        script.setAttribute('src', 'js/libs/scroll.js');
-        return script;
+        let scrollScript = document.createElement('script');
+        scrollScript.setAttribute('src', 'js/libs/scroll.js');
+        return scrollScript;
     }
 
     static addCodingProgressSection() {

--- a/public/js/controllers/ui_controller.js
+++ b/public/js/controllers/ui_controller.js
@@ -29,11 +29,23 @@ export class UIController {
         }
     }
 
-    static addCodingProgressSection() {
-        let DOMstrings = UIController.getDOMstrings(),
-            script = document.createElement('script');
+    static resetUI() {
+        const DOMstrings = UIController.getDOMstrings();
+        UIController.statusBody = document.querySelector(DOMstrings.mainContainer);
+        while (UIController.statusBody.firstChild) {
+            UIController.statusBody.removeChild(UIController.statusBody.firstChild);
+        }
+    }
+
+    static getScrollJsScript() {
+        let script = document.createElement('script');
         script.setAttribute('src', 'js/libs/scroll.js');
-        document.head.appendChild(script);
+        return script;
+    }
+
+    static addCodingProgressSection() {
+        UIController.resetUI();
+        document.head.appendChild(UIController.getScrollJsScript());
         let html = `<div class="container container-fluid table-responsive">
                 <table id='codingtable' class='table'>
                     <thead></thead>
@@ -105,10 +117,8 @@ export class UIController {
     }
 
     static addGraphs(title) {
-        let DOMstrings = UIController.getDOMstrings(),
-            script = document.createElement('script');
-        script.setAttribute('src', 'js/libs/scroll.js');
-        document.head.appendChild(script);
+        UIController.resetUI();
+        document.head.appendChild(UIController.getScrollJsScript());
         let html = `<div class="container"> 
             <div class="d-md-flex justify-content-between p-1">
                 <div>
@@ -191,8 +201,8 @@ export class UIController {
     }
 
     static addSystemsGraphs() {
-        let DOMstrings = UIController.getDOMstrings(),
-            html = `<div class="container"> 
+        UIController.resetUI();
+        let html = `<div class="container"> 
             <section class="d-flex justify-content-end">
                 <span class="font-weight-bold txt-brown mr-1">Last Updated:</span>
                 <div class="font-weight-bold mb-0" id="lastUpdated"></div>


### PR DESCRIPTION
Updated insertion and removal method of DOM elements to enable efficiency. I.e instead of replacing the inner html of the parent element with an empty string when navigating to another page, I have used an efficient way whereby  I remove the child elements of the parent element using a while loop. I've also come up with some functions to prevent repetition of code.  
This PR also solves the issue where the traffic monitoring graphs page replicates during firestore edits.
<img width="1280" alt="duplicate" src="https://user-images.githubusercontent.com/39700595/86139316-3dd13d00-baf8-11ea-9dab-2a0126e2bc10.png">
