### PR TITLE
update the brush feature on area charts

### DIFF
--- a/public/js/libs/area_chart.js
+++ b/public/js/libs/area_chart.js
@@ -267,7 +267,7 @@ export class AreaChart extends GraphLayout {
         this.brush = d3
             .brushX() // Add the brush feature using the d3.brush function
             .extent([
-                [0, 0],
+                [1, 0],
                 [this.width, this.height],
             ]) // initialise the brush area: start at 0,0 and finishes at width,height: it means I select the whole graph area
             .on("end", this.updateChart.bind(this));


### PR DESCRIPTION
<img width="104" alt="Screenshot 2021-01-13 at 14 34 23" src="https://user-images.githubusercontent.com/39700595/104447322-ac657c00-55ac-11eb-8025-9c906534b2b4.png">

This removes the space between the area chart and the the y axis when one applies brushing from the y axis as shown above. This is because the space indicates there was no data received, this is not true because the plotting starts when the axis is at 1 not 0 (This was done to prevent the area chart from overlapping the y axis)