### PR TITLE
Fix Dashboard Broken Links

### DIFF
--- a/public/js/controllers/app_controller.js
+++ b/public/js/controllers/app_controller.js
@@ -80,7 +80,7 @@ class Controller {
         UIController.addSystemsGraphs();
         // Update and show the Graphs
         import("./systems_graphs_controller.js").then((module) => {
-            let unsubscribeFunc = DataController.watchSystemsMetrics(
+            let unsubscribeFunc = DataController.watchServerMetrics(
                 module.SystemsGraphsController.updateGraphs
             );
             DataController.registerSnapshotListener(unsubscribeFunc);

--- a/public/js/controllers/app_controller.js
+++ b/public/js/controllers/app_controller.js
@@ -76,7 +76,7 @@ class Controller {
         DataController.watchATCredits(project, displayATCredits);
     }
 
-    static displaySystems() {
+    static displayServerMetrics() {
         UIController.addSystemsGraphs();
         // Update and show the Graphs
         import("./systems_graphs_controller.js").then((module) => {

--- a/public/js/controllers/app_controller.js
+++ b/public/js/controllers/app_controller.js
@@ -126,20 +126,17 @@ class Controller {
                 .classList.add(Controller.DOMstrings.activeLinkClassName);
             Controller.clearAllTimers();
             DataController.detachSnapshotListener();
-            window.location.hash = "systems";
-            Controller.displaySystems();
+            
+            const [ SERVER, PIPELINES ] = ["miranda", "pipelines"]
+            if (system.toLowerCase() === SERVER) {
+                Controller.displayServerMetrics()
+            }
+            if (system.toLowerCase() === PIPELINES) {
+                Controller.displayPipelines()
+            }
         }
     }
-
-    static navigateToPipelines(e) {
-        if (e.target && e.target.nodeName == "A") {
-            Controller.clearAllTimers();
-            DataController.detachSnapshotListener();
-            window.location.hash = "pipelines";
-            Controller.displayPipelines();
-        }
-    }
-
+    
     static displayDeepLinkedTrafficPage(activeProjectsData) {
         let activeProjects = [],
             page_route = window.location.hash.substring(1);

--- a/public/js/controllers/app_controller.js
+++ b/public/js/controllers/app_controller.js
@@ -126,7 +126,7 @@ class Controller {
                 .classList.add(Controller.DOMstrings.activeLinkClassName);
             Controller.clearAllTimers();
             DataController.detachSnapshotListener();
-            
+            let system = e.target.innerText;
             const [ SERVER, PIPELINES ] = ["miranda", "pipelines"]
             if (system.toLowerCase() === SERVER) {
                 Controller.displayServerMetrics()

--- a/public/js/controllers/app_controller.js
+++ b/public/js/controllers/app_controller.js
@@ -77,11 +77,11 @@ class Controller {
         DataController.registerSnapshotListener(unsubscribeWatchATCredits);
     }
 
-    static displayServerMetrics() {
+    static displayMirandaMetrics() {
         UIController.addSystemsGraphs();
         // Update and show the Graphs
         import("./systems_graphs_controller.js").then((module) => {
-            let unsubscribeFunc = DataController.watchServerMetrics(
+            let unsubscribeFunc = DataController.watchMirandaMetrics(
                 module.SystemsGraphsController.updateGraphs
             );
             DataController.registerSnapshotListener(unsubscribeFunc);
@@ -128,12 +128,11 @@ class Controller {
             Controller.clearAllTimers();
             DataController.detachSnapshotListener();
             let system = e.target.innerText;
-            const [ SERVER, PIPELINES ] = ["miranda", "pipelines"]
-            if (system.toLowerCase() === SERVER) {
-                Controller.displayServerMetrics()
+            if (system.toLowerCase() === "miranda") {
+                Controller.displayMirandaMetrics();
             }
-            if (system.toLowerCase() === PIPELINES) {
-                Controller.displayPipelines()
+            if (system.toLowerCase() === "pipelines") {
+                Controller.displayPipelines();
             }
         }
     }

--- a/public/js/controllers/app_controller.js
+++ b/public/js/controllers/app_controller.js
@@ -78,10 +78,6 @@ class Controller {
 
     static displaySystems() {
         UIController.addSystemsGraphs();
-        Controller.resetActiveLink();
-        document
-            .querySelector(Controller.DOMstrings.systemsLinkSelector)
-            .classList.add(Controller.DOMstrings.activeLinkClassName);
         // Update and show the Graphs
         import("./systems_graphs_controller.js").then((module) => {
             let unsubscribeFunc = DataController.watchSystemsMetrics(
@@ -93,10 +89,6 @@ class Controller {
 
     static displayPipelines() {
         UIController.addPipelinesGraphs();
-        Controller.resetActiveLink();
-        document
-            .querySelector(Controller.DOMstrings.pipelinesLinkSelector)
-            .classList.add(Controller.DOMstrings.activeLinkClassName);
         // Update and show the Graphs
         import("./pipelines_controller.js").then((module) => {
             let unsubscribeFunc = DataController.watchPipelinesMetrics(
@@ -128,6 +120,10 @@ class Controller {
 
     static navigateToSystems(e) {
         if (e.target && e.target.nodeName == "A") {
+            Controller.resetActiveLink();
+            document
+                .querySelector(Controller.DOMstrings.systemsLinkSelector)
+                .classList.add(Controller.DOMstrings.activeLinkClassName);
             Controller.clearAllTimers();
             DataController.detachSnapshotListener();
             window.location.hash = "systems";

--- a/public/js/controllers/app_controller.js
+++ b/public/js/controllers/app_controller.js
@@ -117,8 +117,8 @@ class Controller {
             Controller.displayProject(project);
         }
     }
-
-    static navigateToSystems(e) {
+    
+    static navigateToSelectedSystem(e) {
         if (e.target && e.target.nodeName == "A") {
             Controller.resetActiveLink();
             document

--- a/public/js/controllers/app_controller.js
+++ b/public/js/controllers/app_controller.js
@@ -17,11 +17,8 @@ class Controller {
             .querySelector(Controller.DOMstrings.projectMenu)
             .addEventListener("click", Controller.navigateToSelectedProject);
         document
-            .querySelector(Controller.DOMstrings.systemsLinkSelector)
-            .addEventListener("click", Controller.navigateToSystems);
-        document
-            .querySelector(Controller.DOMstrings.pipelinesLinkSelector)
-            .addEventListener("click", Controller.navigateToPipelines);
+            .querySelector(Controller.DOMstrings.systemsMenu)
+            .addEventListener("click", Controller.navigateToSelectedSystem);
     }
 
     static clearAllTimers() {

--- a/public/js/controllers/data_controller.js
+++ b/public/js/controllers/data_controller.js
@@ -214,7 +214,7 @@ export class DataController {
         onChange({ data, dateRange, projectCollection, operators });
     }
 
-    static watchSystemsMetrics(onChange) {
+    static watchServerMetrics(onChange) {
         const TIMERANGE = 30;
         let offset = new Date();
         offset.setDate(offset.getDate() - TIMERANGE);

--- a/public/js/controllers/data_controller.js
+++ b/public/js/controllers/data_controller.js
@@ -214,7 +214,7 @@ export class DataController {
         onChange({ data, dateRange, projectCollection, operators });
     }
 
-    static watchServerMetrics(onChange) {
+    static watchMirandaMetrics(onChange) {
         const TIMERANGE = 7;
         let offset = new Date();
         offset.setDate(offset.getDate() - TIMERANGE);

--- a/public/js/controllers/ui_controller.js
+++ b/public/js/controllers/ui_controller.js
@@ -2,15 +2,15 @@
 export class UIController {
     static getDOMstrings() {
         return {
-            projectMenu: ".project-menu",
-            codingProgressLinkSelector: ".coding-progress-link",
-            trafficsLinkSelector: ".traffics-link",
-            systemsLinkSelector: ".systems-link",
-            pipelinesLinkSelector: ".pipelines-link",
-            logoutBtn: ".logout-btn",
+            projectMenu: "#traffic-menu",
+            systemsMenu: "#systems-menu",
+            codingProgressLinkSelector: "#coding-progress-link",
+            trafficsLinkSelector: "#traffic-link",
+            systemsLinkSelector: "#systems-link",
+            logoutBtn: "#logout-btn",
+            mainContainer: "#main-container",
             activeLinkClassName: "active-link",
             activeLinks: "a.active-link",
-            mainContainer: ".main-container"
         };
     }
 


### PR DESCRIPTION
Review #302  first
I'm not updating the hash parameters when navigating to the links under systems; this is because I'll open another PR that enables using URL parameters instead of the hash parameters e.g. 
`hostname/#traffic-GPSDD-BUNGOMA` -> `hostname/view?traffic=GPSDD-BUNGOMA`